### PR TITLE
Use device locale to call Arasaac API

### DIFF
--- a/app/src/main/java/com/architectcoders/aacboard/model/PictogramsRepository.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/model/PictogramsRepository.kt
@@ -1,13 +1,12 @@
 package com.architectcoders.aacboard.model
 
+import java.util.*
+
 class PictogramsRepository {
 
-    companion object {
-        private const val DEFAULT_LOCALE = "es"
-    }
-
     suspend fun searchPictograms(searchString: String):List<DomainPictogram> {
-        val arasaacPictograms = RemoteConnection.service.searchPictos(DEFAULT_LOCALE, searchString)
+        val locale= Locale.getDefault().getLanguage()
+        val arasaacPictograms = RemoteConnection.service.searchPictos(locale, searchString)
         return arasaacPictograms.map {it.toDomainPictogram()}
     }
 


### PR DESCRIPTION
# New Pull Request
### Description
Use device locale to call Arasaac API from repository. 
I have used Java Locale to get the current default language although there may be scenarios where this value is not correct (see https://stackoverflow.com/questions/4212320/get-the-current-language-in-device for more information)

### Fixes
#23