### PR TITLE
New Use Case to observe both changes in preferred id and Dashboard

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.20" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="temurin-11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/architectcoders/aacboard/database/dao/DashboardDao.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/database/dao/DashboardDao.kt
@@ -13,7 +13,7 @@ interface DashboardDao {
     fun getDashboards(): Flow<List<DashboardEntity>>
 
     @Query("SELECT * FROM DashboardEntity where id = :id")
-    suspend fun getDashboard(id: Int): DashboardEntityWithCellEntities?
+    fun getDashboard(id: Int): Flow<DashboardEntityWithCellEntities?>
 
     @Query(
         "SELECT * FROM CellEntity where " +

--- a/app/src/main/java/com/architectcoders/aacboard/datasource/local/DashboardLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/datasource/local/DashboardLocalDataSourceImpl.kt
@@ -15,15 +15,15 @@ import kotlinx.coroutines.flow.map
 class DashboardLocalDataSourceImpl(private val dashboardDao: DashboardDao) :
     DashboardLocalDataSource {
 
-    override suspend fun getDashboards(): Flow<List<Dashboard>> =
+    override fun getDashboards(): Flow<List<Dashboard>> =
         dashboardDao.getDashboards().map { list ->
             list.map { dashboard ->
                 dashboard.toDashboard()
             }
         }
 
-    override suspend fun getDashBoardWithCells(id: Int): DashboardWithCells? =
-        dashboardDao.getDashboard(id)?.toDashboardWithCells()
+    override fun getDashBoardWithCells(id: Int): Flow<DashboardWithCells?> =
+        dashboardDao.getDashboard(id).map { it?.toDashboardWithCells() }
 
     override suspend fun saveDashboard(dashboard: DashboardWithCells) {
         dashboardDao.insertDashboard(dashboard.toDashboardEntity())

--- a/app/src/main/java/com/architectcoders/aacboard/di/UseCaseModule.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/di/UseCaseModule.kt
@@ -3,6 +3,7 @@ package com.architectcoders.aacboard.di
 import com.architectcoders.aacboard.domain.use_case.dashboard.delete.DeleteDashboardUseCase
 import com.architectcoders.aacboard.domain.use_case.dashboard.get.GetAllDashboardsUseCase
 import com.architectcoders.aacboard.domain.use_case.dashboard.get.GetDashboardUseCase
+import com.architectcoders.aacboard.domain.use_case.dashboard.get.GetMainDashboardUseCase
 import com.architectcoders.aacboard.domain.use_case.dashboard.get.GetPreferredDashboardIdUseCase
 import com.architectcoders.aacboard.domain.use_case.dashboard.save.SaveDashboardUseCase
 import com.architectcoders.aacboard.domain.use_case.dashboard.save.SetPreferredDashboardIdUseCase
@@ -11,6 +12,7 @@ import org.koin.dsl.module
 val useCaseModule = module {
     factory { DeleteDashboardUseCase(get()) }
     factory { GetAllDashboardsUseCase(get()) }
+    factory { GetMainDashboardUseCase(get(), get()) }
     factory { GetDashboardUseCase(get()) }
     factory { GetPreferredDashboardIdUseCase(get()) }
     factory { SaveDashboardUseCase(get()) }

--- a/app/src/main/java/com/architectcoders/aacboard/di/UseCaseModule.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/di/UseCaseModule.kt
@@ -12,7 +12,7 @@ import org.koin.dsl.module
 val useCaseModule = module {
     factory { DeleteDashboardUseCase(get()) }
     factory { GetAllDashboardsUseCase(get()) }
-    factory { GetMainDashboardUseCase(get(), get()) }
+    factory { GetMainDashboardUseCase(get()) }
     factory { GetDashboardUseCase(get()) }
     factory { GetPreferredDashboardIdUseCase(get()) }
     factory { SaveDashboardUseCase(get()) }

--- a/app/src/main/java/com/architectcoders/aacboard/di/ViewModelModule.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/di/ViewModelModule.kt
@@ -7,5 +7,5 @@ import org.koin.dsl.module
 
 val viewModelModule = module {
     viewModel { ListDashboardsViewModel(get(), get(), get(), get(), get()) }
-    viewModel { MainDashboardViewModel(get(), get()) }
+    viewModel { MainDashboardViewModel(get()) }
 }

--- a/app/src/main/java/com/architectcoders/aacboard/ui/fragments/viewmodel/MainDashboardViewModel.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/ui/fragments/viewmodel/MainDashboardViewModel.kt
@@ -4,14 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.architectcoders.aacboard.domain.data.cell.CellPictogram
 import com.architectcoders.aacboard.domain.data.dashboard.DashboardWithCells
-import com.architectcoders.aacboard.domain.use_case.dashboard.get.GetDashboardUseCase
-import com.architectcoders.aacboard.domain.use_case.dashboard.get.GetPreferredDashboardIdUseCase
+import com.architectcoders.aacboard.domain.use_case.dashboard.get.GetMainDashboardUseCase
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class MainDashboardViewModel(
-    getPreferredDashboardIdUseCase: GetPreferredDashboardIdUseCase,
-    getDashboardUseCase: GetDashboardUseCase,
+    getMainDashboardUseCase: GetMainDashboardUseCase
 ) : ViewModel() {
 
     private val _state: MutableStateFlow<MainDashboardUiState> = MutableStateFlow(
@@ -21,8 +19,7 @@ class MainDashboardViewModel(
 
     init {
         viewModelScope.launch {
-            getPreferredDashboardIdUseCase().collect { id ->
-                val dashboard = getDashboardUseCase(id)
+            getMainDashboardUseCase().collect { dashboard ->
                 updateUiState(_state.value.copy(dashboard = dashboard, loading = false))
             }
         }

--- a/app/src/main/java/com/architectcoders/aacboard/ui/fragments/viewmodel/MainDashboardViewModel.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/ui/fragments/viewmodel/MainDashboardViewModel.kt
@@ -36,13 +36,13 @@ class MainDashboardViewModel(
         updateUiState(_state.value.copy(selectedCellPictograms = emptyList()))
     }
 
-    private fun updateUiState(newUiState: MainDashboardUiState) {
-        _state.update { newUiState }
-    }
-
     fun onClearLastSelectionClicked() {
         val selection = _state.value.selectedCellPictograms.dropLast(1)
         updateUiState(_state.value.copy(selectedCellPictograms = selection))
+    }
+
+    private fun updateUiState(newUiState: MainDashboardUiState) {
+        _state.update { newUiState }
     }
 
     data class MainDashboardUiState(

--- a/app/src/main/java/com/architectcoders/aacboard/ui/utils/CoroutinesExtensions.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/ui/utils/CoroutinesExtensions.kt
@@ -1,11 +1,33 @@
 package com.architectcoders.aacboard.ui.utils
 
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+
+fun <T, U> Fragment.diff(
+    forParentFlow: Flow<T>,
+    mapToChildFlow: (T) -> U,
+    body: (U) -> Unit
+) {
+    forParentFlow.diff(viewLifecycleOwner, mapToChildFlow, body)
+}
+
+fun <T, U> Flow<T>.diff(
+    lifecycleOwner: LifecycleOwner,
+    mapF: (T) -> U,
+    body: (U) -> Unit
+) {
+    lifecycleOwner.launchAndCollect(
+        flow = map(mapF).distinctUntilChanged(),
+        body = body
+    )
+}
 
 fun <T> LifecycleOwner.launchAndCollect(
     flow: Flow<T>,

--- a/app/src/main/java/com/architectcoders/aacboard/ui/utils/ViewExtensions.kt
+++ b/app/src/main/java/com/architectcoders/aacboard/ui/utils/ViewExtensions.kt
@@ -53,6 +53,10 @@ fun ViewAnimator.show(view: View) {
     displayedChild = indexOfChild(view)
 }
 
+fun View.toggleVisibility(visible: Boolean) {
+    this.visibility = if (visible) View.VISIBLE else View.GONE
+}
+
 fun FragmentMainDashboardBinding.showView(view: View) {
     viewAnimator.show(view)
 }

--- a/app/src/main/res/layout/fragment_main_dashboard.xml
+++ b/app/src/main/res/layout/fragment_main_dashboard.xml
@@ -7,6 +7,18 @@
     android:fitsSystemWindows="true"
     tools:context=".ui.fragments.MainDashboardFragment">
 
+    <LinearLayout
+        android:id="@+id/progress_bar_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center">
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
     <ViewAnimator
         android:id="@+id/view_animator"
         android:layout_width="match_parent"
@@ -15,18 +27,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
-
-        <LinearLayout
-            android:id="@+id/progress_bar_container"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center">
-
-            <ProgressBar
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-
-        </LinearLayout>
 
         <LinearLayout
             android:id="@+id/dashboard_container"

--- a/app/src/main/res/values/splash_themes.xml
+++ b/app/src/main/res/values/splash_themes.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Theme.AppSplash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/white</item>
-        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_foreground</item>
         <item name="windowSplashScreenAnimationDuration">1000</item>
         <item name="postSplashScreenTheme">@style/Theme.AACBoard</item>
 

--- a/data/src/main/java/com/architectcoders/aacboard/data/datasource/local/DashboardLocalDataSource.kt
+++ b/data/src/main/java/com/architectcoders/aacboard/data/datasource/local/DashboardLocalDataSource.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface DashboardLocalDataSource {
 
-    suspend fun getDashboards(): Flow<List<Dashboard>>
+    fun getDashboards(): Flow<List<Dashboard>>
 
-    suspend fun getDashBoardWithCells(id: Int): DashboardWithCells?
+    fun getDashBoardWithCells(id: Int): Flow<DashboardWithCells?>
 
     suspend fun saveDashboard(dashboard: DashboardWithCells)
 

--- a/data/src/main/java/com/architectcoders/aacboard/data/repository/PictogramsRepositoryImpl.kt
+++ b/data/src/main/java/com/architectcoders/aacboard/data/repository/PictogramsRepositoryImpl.kt
@@ -8,7 +8,11 @@ import com.architectcoders.aacboard.domain.data.dashboard.Dashboard
 import com.architectcoders.aacboard.domain.data.dashboard.DashboardWithCells
 import com.architectcoders.aacboard.domain.data.cell.CellPictogram
 import com.architectcoders.aacboard.domain.repository.PictogramsRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.mapLatest
 import java.util.Locale
 
 class PictogramsRepositoryImpl(
@@ -21,6 +25,14 @@ class PictogramsRepositoryImpl(
 
     override fun getDashBoardWithCells(id: Int): Flow<DashboardWithCells?> =
         localDataSource.getDashBoardWithCells(id)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun getMainDashboard(): Flow<DashboardWithCells?> =
+        deviceDataSource.getPreferredDashboardId()
+            .distinctUntilChanged()
+            .flatMapLatest {
+                localDataSource.getDashBoardWithCells(it)
+            }
 
     override suspend fun saveDashboard(dashboard: DashboardWithCells) {
         localDataSource.saveDashboard(dashboard)

--- a/data/src/main/java/com/architectcoders/aacboard/data/repository/PictogramsRepositoryImpl.kt
+++ b/data/src/main/java/com/architectcoders/aacboard/data/repository/PictogramsRepositoryImpl.kt
@@ -19,7 +19,7 @@ class PictogramsRepositoryImpl(
 
     override suspend fun getDashboards(): Flow<List<Dashboard>> = localDataSource.getDashboards()
 
-    override suspend fun getDashBoardWithCells(id: Int): DashboardWithCells? =
+    override fun getDashBoardWithCells(id: Int): Flow<DashboardWithCells?> =
         localDataSource.getDashBoardWithCells(id)
 
     override suspend fun saveDashboard(dashboard: DashboardWithCells) {

--- a/domain/src/main/java/com/architectcoders/aacboard/domain/repository/PictogramsRepository.kt
+++ b/domain/src/main/java/com/architectcoders/aacboard/domain/repository/PictogramsRepository.kt
@@ -10,7 +10,7 @@ interface PictogramsRepository {
 
     suspend fun getDashboards(): Flow<List<Dashboard>>
 
-    suspend fun getDashBoardWithCells(id: Int): DashboardWithCells?
+    fun getDashBoardWithCells(id: Int): Flow<DashboardWithCells?>
 
     suspend fun saveDashboard(dashboard: DashboardWithCells)
 

--- a/domain/src/main/java/com/architectcoders/aacboard/domain/repository/PictogramsRepository.kt
+++ b/domain/src/main/java/com/architectcoders/aacboard/domain/repository/PictogramsRepository.kt
@@ -25,4 +25,6 @@ interface PictogramsRepository {
     suspend fun searchPictograms(searchString: String): List<CellPictogram>
 
     fun getPreferredDashboardId(): Flow<Int>
+
+    fun getMainDashboard(): Flow<DashboardWithCells?>
 }

--- a/domain/src/main/java/com/architectcoders/aacboard/domain/use_case/dashboard/delete/DeleteDashboardUseCase.kt
+++ b/domain/src/main/java/com/architectcoders/aacboard/domain/use_case/dashboard/delete/DeleteDashboardUseCase.kt
@@ -8,6 +8,4 @@ class DeleteDashboardUseCase(private val repository: PictogramsRepository): susp
     override suspend fun invoke(id: Int) {
         repository.deleteDashboard(id)
     }
-
-
 }

--- a/domain/src/main/java/com/architectcoders/aacboard/domain/use_case/dashboard/get/GetDashboardUseCase.kt
+++ b/domain/src/main/java/com/architectcoders/aacboard/domain/use_case/dashboard/get/GetDashboardUseCase.kt
@@ -2,12 +2,13 @@ package com.architectcoders.aacboard.domain.use_case.dashboard.get
 
 import com.architectcoders.aacboard.domain.data.dashboard.DashboardWithCells
 import com.architectcoders.aacboard.domain.repository.PictogramsRepository
+import kotlinx.coroutines.flow.Flow
 
 class GetDashboardUseCase(
     private val repository: PictogramsRepository
-) : suspend (Int) -> DashboardWithCells? {
+) : suspend (Int) -> Flow<DashboardWithCells?> {
 
-    override suspend fun invoke(id: Int): DashboardWithCells? {
+    override suspend fun invoke(id: Int): Flow<DashboardWithCells?> {
         return repository.getDashBoardWithCells(id)
     }
 }

--- a/domain/src/main/java/com/architectcoders/aacboard/domain/use_case/dashboard/get/GetMainDashboardUseCase.kt
+++ b/domain/src/main/java/com/architectcoders/aacboard/domain/use_case/dashboard/get/GetMainDashboardUseCase.kt
@@ -1,0 +1,22 @@
+package com.architectcoders.aacboard.domain.use_case.dashboard.get
+
+import com.architectcoders.aacboard.domain.data.dashboard.DashboardWithCells
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+
+class GetMainDashboardUseCase(
+    private val getPreferredDashboardIdUseCase: GetPreferredDashboardIdUseCase,
+    private val getDashboardUseCase: GetDashboardUseCase,
+): suspend () -> Flow<DashboardWithCells?> {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend fun invoke(): Flow<DashboardWithCells?> =
+        getPreferredDashboardIdUseCase()
+            .distinctUntilChanged()
+            .flatMapLatest {
+                getDashboardUseCase(it)
+
+            }
+}

--- a/domain/src/main/java/com/architectcoders/aacboard/domain/use_case/dashboard/get/GetMainDashboardUseCase.kt
+++ b/domain/src/main/java/com/architectcoders/aacboard/domain/use_case/dashboard/get/GetMainDashboardUseCase.kt
@@ -1,22 +1,12 @@
 package com.architectcoders.aacboard.domain.use_case.dashboard.get
 
 import com.architectcoders.aacboard.domain.data.dashboard.DashboardWithCells
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.architectcoders.aacboard.domain.repository.PictogramsRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
 
 class GetMainDashboardUseCase(
-    private val getPreferredDashboardIdUseCase: GetPreferredDashboardIdUseCase,
-    private val getDashboardUseCase: GetDashboardUseCase,
+    private val repository: PictogramsRepository,
 ): suspend () -> Flow<DashboardWithCells?> {
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    override suspend fun invoke(): Flow<DashboardWithCells?> =
-        getPreferredDashboardIdUseCase()
-            .distinctUntilChanged()
-            .flatMapLatest {
-                getDashboardUseCase(it)
-
-            }
+    override suspend fun invoke(): Flow<DashboardWithCells?> = repository.getMainDashboard()
 }


### PR DESCRIPTION
# New Pull Request
### Description

- Create new use case to react both to preferred changes and dashboard changes 
- Change injection accordingly to the new use case in the view model

In the previous version there was a bug when modifying information on the preferred dashboard (deleting or modifying cells). The view model wasn't notified of those changes thus neither was the UI. This changes are intended to fix this issue by using a new useCase: GetMainDashboardUseCase, to react properly to changes to the preferred dashboard.

Observations:

The GetMainDashboardUseCase depends on 2 other use case, I am not sure how you feel about nesting use cases.

### Fixes
*Please add which issue you are solving with this pull request.*